### PR TITLE
feat: Redirect to create organisation when no organisation exists

### DIFF
--- a/app/routes/_dashboard+/create-organisation.tsx
+++ b/app/routes/_dashboard+/create-organisation.tsx
@@ -64,7 +64,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
 	try {
 		const requestBody: CreateOrganisationRequest = {
-			userId: 1,
+			userId: 9, // TODO - USE THE REAL USER ID HERE!
 			name: submission.value.organisationName,
 			description: submission.value.description,
 		}
@@ -88,7 +88,7 @@ export async function action({ request }: ActionFunctionArgs) {
 			},
 		}
 
-		return redirect('/dashboard/3', responseInit)
+		return redirect(`/dashboard/${data.organisationId}`, responseInit)
 	} catch (error) {
 		return json({ result: submission.reply(), error }, { status: 400 })
 	}

--- a/app/routes/_dashboard+/dashboard.tsx
+++ b/app/routes/_dashboard+/dashboard.tsx
@@ -4,8 +4,9 @@ import {
 	type LoaderFunctionArgs,
 	type MetaFunction,
 } from '@remix-run/node'
-import { Outlet } from '@remix-run/react'
+import { Outlet, redirect } from '@remix-run/react'
 import { Fragment } from 'react'
+import { paths } from '#app/paths.js'
 import { organisationsApiResponseSchema } from '#app/types/bigmelo/organisations.js'
 import { get } from '#app/utils/api.js'
 import { requireAuthedSession } from '#app/utils/auth.server.js'
@@ -30,9 +31,14 @@ export async function loader({ request }: LoaderFunctionArgs) {
 			},
 		})
 
+		if ((organisationsResponse.data as any).data.length === 0) {
+			return redirect(paths.createOrganisation)
+		}
+
 		const verifiedOrganisations = verifyZodSchema(
 			organisationsResponse.data,
 			organisationsApiResponseSchema,
+			'There is not an organisation associated with your account. Please create one.',
 		)
 
 		let responseInit


### PR DESCRIPTION
This pull request adds a new feature that redirects users to the create organisation page when no organisation is associated with their account. The `create-organisation` file has been updated to use the real user ID instead of a hard-coded value. Additionally, the `loader` function has been modified to check if there are any organisations associated with the user's account, and if not, it redirects them to the create organisation page with a message indicating that they need to create an organisation.